### PR TITLE
팀 생성, 내 팀 조회

### DIFF
--- a/src/main/java/backend/teamble/project/Membership.java
+++ b/src/main/java/backend/teamble/project/Membership.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -27,6 +28,12 @@ public class Membership {
     @JoinColumn(name = "projectId", nullable = false)
     private Project project;
 
+    @CreationTimestamp
     private LocalDateTime joinedAt;
+
+    public Membership(User user, Project project) {
+        this.user = user;
+        this.project = project;
+    }
 }
 

--- a/src/main/java/backend/teamble/project/MembershipRepository.java
+++ b/src/main/java/backend/teamble/project/MembershipRepository.java
@@ -2,5 +2,5 @@ package backend.teamble.project;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProjectRepository extends JpaRepository<Project, Long> {
+public interface MembershipRepository extends JpaRepository<Membership, Long> {
 }

--- a/src/main/java/backend/teamble/project/MembershipRepository.java
+++ b/src/main/java/backend/teamble/project/MembershipRepository.java
@@ -1,6 +1,13 @@
 package backend.teamble.project;
 
+import backend.teamble.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MembershipRepository extends JpaRepository<Membership, Long> {
+
+    List<Membership> findByUser(User user);
 }

--- a/src/main/java/backend/teamble/project/Project.java
+++ b/src/main/java/backend/teamble/project/Project.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,11 +19,19 @@ import java.util.List;
 public class Project {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
     private String topic;
+
+    @CreationTimestamp
     private LocalDateTime createdAt;
+
+    public Project(String name, String topic) {
+        this.name = name;
+        this.topic = topic;
+    }
 
     @OneToMany(mappedBy = "project")
     private List<Schedule> schedules;
@@ -32,6 +41,8 @@ public class Project {
 
     @OneToMany(mappedBy = "project")
     private List<Membership> memberships;
+
+
 
 
 }

--- a/src/main/java/backend/teamble/project/ProjectController.java
+++ b/src/main/java/backend/teamble/project/ProjectController.java
@@ -2,15 +2,20 @@ package backend.teamble.project;
 
 import backend.teamble.project.dto.CreateTeamRequest;
 import backend.teamble.project.dto.CreateTeamResponse;
+import backend.teamble.project.dto.MyTeamsResponse;
+import backend.teamble.project.dto.MyTeamsResponseWrapper;
 import backend.teamble.security.CustomUserDetails;
 import backend.teamble.user.User;
 import backend.teamble.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,6 +29,13 @@ public class ProjectController {
         Project project = projectService.createTeam(createTeamRequest.getTeamName(), createTeamRequest.getTopic(), user);
         CreateTeamResponse response = new CreateTeamResponse(project.getId(), "팀이 성공적으로 생성되었습니다.");
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/teams/my")
+    ResponseEntity<?> getMyTeams(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        User user = userRepository.findByEmail(userDetails.getUsername()).orElseThrow();
+        List<MyTeamsResponse> response = projectService.getMyTeams(user);
+        return ResponseEntity.ok(new MyTeamsResponseWrapper(response));
     }
 
 }

--- a/src/main/java/backend/teamble/project/ProjectController.java
+++ b/src/main/java/backend/teamble/project/ProjectController.java
@@ -1,4 +1,29 @@
 package backend.teamble.project;
 
+import backend.teamble.project.dto.CreateTeamRequest;
+import backend.teamble.project.dto.CreateTeamResponse;
+import backend.teamble.security.CustomUserDetails;
+import backend.teamble.user.User;
+import backend.teamble.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
 public class ProjectController {
+    private final ProjectService projectService;
+    private final UserRepository userRepository;
+
+    @PostMapping("/teams")
+    ResponseEntity<?> addTeam(@RequestBody CreateTeamRequest createTeamRequest, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        User user = userRepository.findByEmail(userDetails.getUsername()).orElseThrow();
+        Project project = projectService.createTeam(createTeamRequest.getTeamName(), createTeamRequest.getTopic(), user);
+        CreateTeamResponse response = new CreateTeamResponse(project.getId(), "팀이 성공적으로 생성되었습니다.");
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/backend/teamble/project/ProjectService.java
+++ b/src/main/java/backend/teamble/project/ProjectService.java
@@ -1,4 +1,25 @@
 package backend.teamble.project;
 
+import backend.teamble.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ProjectService {
+    private final ProjectRepository projectRepository;
+    private final MembershipRepository membershipRepository;
+
+    @Transactional
+    public Project createTeam(String teamName, String topic, User user) {
+        Project project = new Project(teamName, topic);
+        projectRepository.save(project);
+
+        Membership membership = new Membership(user, project);
+        membershipRepository.save(membership);
+
+        return project;
+    }
 }

--- a/src/main/java/backend/teamble/project/ProjectService.java
+++ b/src/main/java/backend/teamble/project/ProjectService.java
@@ -1,9 +1,13 @@
 package backend.teamble.project;
 
+import backend.teamble.project.dto.MyTeamsResponse;
 import backend.teamble.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,5 +25,16 @@ public class ProjectService {
         membershipRepository.save(membership);
 
         return project;
+    }
+
+    public List<MyTeamsResponse> getMyTeams(User user) {
+        List<Membership> memberships = membershipRepository.findByUser(user);
+
+        return memberships.stream()
+                .map(membership -> {
+                    Project project = membership.getProject();
+                    return new MyTeamsResponse(project.getId(), project.getName());
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/backend/teamble/project/dto/CreateTeamRequest.java
+++ b/src/main/java/backend/teamble/project/dto/CreateTeamRequest.java
@@ -1,4 +1,11 @@
 package backend.teamble.project.dto;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
 public class CreateTeamRequest {
+    private String teamName;
+    private String topic;
 }

--- a/src/main/java/backend/teamble/project/dto/CreateTeamResponse.java
+++ b/src/main/java/backend/teamble/project/dto/CreateTeamResponse.java
@@ -1,0 +1,12 @@
+package backend.teamble.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+public class CreateTeamResponse {
+    private Long teamId;
+    private String Message;
+}

--- a/src/main/java/backend/teamble/project/dto/MyTeamsResponse.java
+++ b/src/main/java/backend/teamble/project/dto/MyTeamsResponse.java
@@ -1,0 +1,11 @@
+package backend.teamble.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MyTeamsResponse {
+    private Long teamId;
+    private String teamName;
+}

--- a/src/main/java/backend/teamble/project/dto/MyTeamsResponseWrapper.java
+++ b/src/main/java/backend/teamble/project/dto/MyTeamsResponseWrapper.java
@@ -1,0 +1,12 @@
+package backend.teamble.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class MyTeamsResponseWrapper {
+    private List<MyTeamsResponse> teams;
+}

--- a/src/main/java/backend/teamble/security/CustomUserDetails.java
+++ b/src/main/java/backend/teamble/security/CustomUserDetails.java
@@ -1,0 +1,30 @@
+package backend.teamble.security;
+
+import backend.teamble.user.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomUserDetails(User user) {this.user = user;}
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+}

--- a/src/main/java/backend/teamble/security/CustomUserDetailsService.java
+++ b/src/main/java/backend/teamble/security/CustomUserDetailsService.java
@@ -1,0 +1,25 @@
+package backend.teamble.security;
+
+import backend.teamble.user.User;
+import backend.teamble.user.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/backend/teamble/security/JwtAuthenticationFilter.java
+++ b/src/main/java/backend/teamble/security/JwtAuthenticationFilter.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService customUserDetailsService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -25,9 +26,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
         if (token != null && jwtTokenProvider.validateToken(token)) {
             String email = jwtTokenProvider.getEmailFromToken(token);
+            CustomUserDetails userDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(email);
             UsernamePasswordAuthenticationToken auth =
                     new UsernamePasswordAuthenticationToken(
-                            email,
+                            userDetails,
                             null,
                             Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")) // ← 권한 추가
                     );

--- a/src/main/java/backend/teamble/security/WebSecurityConfig.java
+++ b/src/main/java/backend/teamble/security/WebSecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class WebSecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService customUserDetailsService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -28,7 +29,7 @@ public class WebSecurityConfig {
                         .requestMatchers("/users/login", "/users/signup").permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, customUserDetailsService), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }


### PR DESCRIPTION
JwtAuthenticationFilter에 doFilterInternal에서 UsernamePasswordAuthenticationToken 생성할때 principal에 기존 email 값을 넣던걸 userDetails로 수정했습니다. 이유는 SecurityContextHolder에서 바로 인증된 유저 객체를 가져와서 사용하기 위함입니다.

